### PR TITLE
docs: correct eval flag defaults in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ Useful flags:
 
 - `--num-worlds N` — independent random scenes (default 5).
 - `--num-chunks N` — action chunks per rollout; each chunk is
-`--execute-chunk-dim` actions (defaults: 60 chunks × 15 = 900 sim steps).
+`--execute-chunk-dim` actions (defaults: 120 chunks × 15 = 1800 sim steps).
 - `--diffusion-steps N` — flow-matching Euler steps per inference
 (default 10, matches production).
 - `--checkpoint` — accepts a local `.pt` path or `s3://…/<file>.pt`.
@@ -142,10 +142,10 @@ one bundled in the checkpoint).
 - `--fast-inference` / `--no-fast-inference` (default on) — bf16 +
 torch.compile + CUDA-graph captured `sample_actions`. ~5× faster
 inference; first call pays a one-time ~25 s compile cost.
-- `--vanilla-physics` / `--no-vanilla-physics` (default on) — use
-vanilla CPU `mujoco.mj_step` for env physics instead of single-world
-mjwarp.  This is because for single environments, it's faster to
-use vanilla mujoco. Rendering still happens in MJWarp.
+- `--vanilla-physics` / `--no-vanilla-physics` (default off) — enable
+vanilla CPU `mujoco.mj_step` for env physics instead of the default
+single-world mjwarp path.  This is because for single environments, it's
+faster to use vanilla mujoco. Rendering still happens in MJWarp.
 
 Note that the first launch compiles MJWarp's CUDA kernels (~1 min).
 


### PR DESCRIPTION
## Summary
Corrects two flag defaults in the README "Useful flags" section that disagreed with the code:

- `--num-chunks` defaults to **120** (1800 sim steps), not 60 (900). `SimEvalConfig.num_chunks = 120` in `abc_minimal/config.py`.
- `--vanilla-physics` is **off** by default. `SimEvalConfig.vanilla_physics = False`, so the default eval path runs single-world mjwarp; the README labeled it "default on", which inverts the actual behavior.

The adjacent `--fast-inference (default on)` is correct (`= True`), confirming these labels are meant to track the config.

AI was used for assistance.
